### PR TITLE
Support for deuterocanonical works via config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .git
 .yardoc
+.idea

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,22 @@
 PATH
   remote: .
   specs:
-    bible_bot (2.0.2)
+    bible_bot (2.1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
     diff-lcs (1.3)
+    io-console (0.5.9)
+    irb (1.3.7)
+      reline (>= 0.2.7)
     method_source (1.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    reline (0.2.7)
+      io-console (~> 0.5)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -31,6 +36,7 @@ PLATFORMS
 
 DEPENDENCIES
   bible_bot!
+  irb
   pry
   rspec (~> 3.5.0)
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,19 @@ verse == other_verse
 verse > other_verse
 ```
 
+## Deuterocanonical References
+
+If you want to match deuterocanonical references in your strings, you can enable a collection of matchers like this:
+
+```ruby
+BibleBot.include_deuterocanonical_content = true
+
+ReferenceMatch.scan( "Tob 1:1" ).first.reference.formatted
+
+# > "Tobit 1:1"
+```
+
+You can see the supported deuterocanonical works in [bible.rb](https://github.com/LittleLea/bible_bot/blob/b94fe9b3948ceb23d39961ffdc4bdf7ffe23eff3/lib/bible_bot/bible.rb#L537)
 
 ## History
 

--- a/bible_bot.gemspec
+++ b/bible_bot.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rspec', '~> 3.5.0'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'irb'
 end

--- a/lib/bible_bot.rb
+++ b/lib/bible_bot.rb
@@ -1,3 +1,4 @@
+require "ostruct"
 require "bible_bot/version"
 require "bible_bot/book"
 require "bible_bot/bible"
@@ -5,3 +6,38 @@ require "bible_bot/errors"
 require "bible_bot/verse"
 require "bible_bot/reference"
 require "bible_bot/reference_match"
+
+module BibleBot
+  DEFAULTS = {
+    include_deuterocanonical_content: false
+  }
+
+  def self.options
+    @options ||= OpenStruct.new(DEFAULTS.dup)
+  end
+
+  def self.options=(opts)
+    @options = opts
+  end
+
+  ##
+  # Configuration for BibleBot, use like:
+  #
+  #   BibleBot.configure do |config|
+  #     config.include_deuterocanonical_content = true
+  #   end
+  def self.configure
+    yield(options)
+  end
+
+  def self.include_deuterocanonical_content?
+    !!self.options.include_deuterocanonical_content
+  end
+
+  def self.include_deuterocanonical_content=(inc)
+    self.options.include_deuterocanonical_content = (inc === true)
+
+    # We need to reset the stored regexps because they take content into account.
+    BibleBot::Bible.reset_regular_expressions
+  end
+end

--- a/lib/bible_bot/bible.rb
+++ b/lib/bible_bot/bible.rb
@@ -579,7 +579,7 @@ module BibleBot
         id: 106,
         name: "Ecclesiasticus", # a.k.a. Sirach
         abbreviation: "Ecclus",
-        regex: "(?:(Eccle?u?s))",
+        regex: "(?:Ecclus|Ecclesiasticus)",
         testament: "",
         chapters: [29, 18, 30, 31, 17, 37, 36, 19, 18, 30, 34, 18, 25, 27, 20, 28, 27, 33, 26, 30, 28, 27, 27, 31, 25, 20, 30, 26, 28, 25, 31, 24, 33, 26, 24, 27, 30, 34, 35, 30, 24, 25, 35, 23, 26, 20, 25, 25, 16, 29, 30],
       ),

--- a/lib/bible_bot/bible.rb
+++ b/lib/bible_bot/bible.rb
@@ -534,8 +534,176 @@ module BibleBot
       )
     ]
 
+    @@deuterocanonical_books = [
+      Book.new(
+        id: 101,
+        name: "Tobit",
+        abbreviation: "Tob",
+        regex: "Tob(?:it)?",
+        testament: "",
+        chapters: [22, 14, 17, 21, 22, 18, 17, 21, 6, 14, 18, 22, 18, 15],
+      ),
+      Book.new(
+        id: 102,
+        name: "Judith",
+        abbreviation: "Jth",
+        regex: "(?:Ju?d?i?th?)",
+        testament: "",
+        chapters: [16, 28, 10, 15, 24, 21, 32, 36, 14, 23, 23, 20, 20, 19, 14, 25],
+      ),
+      Book.new(
+        id: 103,
+        name: "Additions to Esther",
+        abbreviation: "Add Esth",
+        regex: "(?:((Add\s?|(The\s)?Rest\sof\s|A))Est?h?e?r?)",
+        testament: "",
+        chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 8, 30, 16, 24, 10],
+      ),
+      Book.new(
+        id: 104,
+        name: "Wisdom of Solomon",
+        abbreviation: "Wis",
+        regex: "(?:(Wi?sd?\.?(\sof\s)?(Sol|om)?))",
+        testament: "",
+        chapters: [16, 24, 19, 20, 23, 25, 30, 21, 18, 21, 26, 27, 19, 31, 19, 29, 21, 25, 22],
+      ),
+      Book.new(
+        id: 105,
+        name: "Sirach", # a.k.a. Ecclesiasticus
+        abbreviation: "Sir",
+        regex: "Sir(?:ach)?",
+        testament: "",
+        chapters: [29, 18, 30, 31, 17, 37, 36, 19, 18, 30, 34, 18, 25, 27, 20, 28, 27, 33, 26, 30, 28, 27, 27, 31, 25, 20, 30, 26, 28, 25, 31, 24, 33, 26, 24, 27, 30, 34, 35, 30, 24, 25, 35, 23, 26, 20, 25, 25, 16, 29, 30],
+      ),
+      Book.new(
+        id: 106,
+        name: "Ecclesiasticus", # a.k.a. Sirach
+        abbreviation: "Ecclus",
+        regex: "(?:(Eccle?u?s))",
+        testament: "",
+        chapters: [29, 18, 30, 31, 17, 37, 36, 19, 18, 30, 34, 18, 25, 27, 20, 28, 27, 33, 26, 30, 28, 27, 27, 31, 25, 20, 30, 26, 28, 25, 31, 24, 33, 26, 24, 27, 30, 34, 35, 30, 24, 25, 35, 23, 26, 20, 25, 25, 16, 29, 30],
+      ),
+      Book.new(
+        id: 107,
+        name: "Baruch",
+        abbreviation: "Bar",
+        regex: "Bar(?:uch)?",
+        testament: "",
+        chapters: [22, 35, 38, 37, 9, 72],
+      ),
+      Book.new(
+        id: 108,
+        name: "Letter of Jeremiah", # Often placed as Baruch 6, but sometimes stands alone
+        abbreviation: "Ep Jer",
+        regex: "(?:((Le?t?t?e?r?|Ep)(\.\s|\sof\s)?Jer?))",
+        testament: "",
+        chapters: [73],
+      ),
+      Book.new(
+        id: 109,
+        name: "Song of Three Youths", # An extension of Daniel 3... a.k.a. Prayer of Azariah
+        abbreviation: "Sg of 3 Childr",
+        regex: "(?:(((The\s)?(So?n?g)(\.?\s?o?f?\s?)(the\s)?(3|Thr).*))|((Pr)?.*Aza?r?))",
+        testament: "",
+        chapters: [],
+      ),
+      Book.new(
+        id: 110,
+        name: "Susanna", # A book of Daniel
+        abbreviation: "Sus",
+        regex: "(?:(Sus))",
+        testament: "",
+        chapters: [64],
+      ),
+      Book.new(
+        id: 111,
+        name: "Bel and the Dragon", # A book of Daniel
+        abbreviation: "Bel and Dr",
+        regex: "(?:(Bel))",
+        testament: "",
+        chapters: [42],
+      ),
+      Book.new(
+        id: 112,
+        name: "1 Maccabees",
+        abbreviation: "1 Macc",
+        #regex: "(?:((1s?t?|^I{1}|First)\s?Ma?c?))",
+        regex: "(?:1|I)(?:\\s)?Macc(?:abees)?",
+        testament: "",
+        chapters: [63, 70, 59, 61, 68, 63, 50, 32, 73, 89, 74, 53, 53, 49, 41, 24],
+      ),
+      Book.new(
+        id: 113,
+        name: "2 Maccabees",
+        abbreviation: "2 Macc",
+        regex: "(?:((2n?d?|^I{2}|Second)\s?Ma?c?))",
+        testament: "",
+        chapters: [36, 32, 40, 50, 27, 31, 42, 36, 29, 38, 38, 46, 26, 46, 39],
+      ),
+      Book.new(
+        id: 114,
+        name: "3 Maccabees",
+        abbreviation: "3 Macc",
+        regex: "(?:((3r?d?|^I{3}|Third)\s?Ma?c?))",
+        testament: "",
+        chapters: [29, 33, 30, 21, 51, 41, 23],
+      ),
+      Book.new(
+        id: 115,
+        name: "4 Maccabees",
+        abbreviation: "4 Macc",
+        regex: "(?:((4t?h?|IV|Fourth)\s?Ma?c?))",
+        testament: "",
+        chapters: [35, 24, 21, 26, 38, 35, 23, 29, 32, 21, 27, 19, 27, 20, 32, 25, 24, 24],
+      ),
+      Book.new(
+        id: 116,
+        name: "1 Esdras",
+        abbreviation: "1 Esd",
+        regex: "(?:((1s?t?|^I{1}|First)\s?Esd?))",
+        testament: "",
+        chapters: [58, 30, 24, 63, 73, 34, 15, 96, 55],
+      ),
+      Book.new(
+        id: 117,
+        name: "2 Esdras",
+        abbreviation: "2 Esd",
+        regex: "(?:((2n?d?|^I{2}|Second)\s?Esd?))",
+        testament: "",
+        chapters: [40, 48, 36, 52, 56, 59, 140, 63, 47, 59, 46, 51, 58, 48, 63, 78],
+      ),
+      Book.new(
+        id: 118,
+        name: "Prayer of Manasseh",
+        abbreviation: "Pr of Man",
+        regex: "(?:(Pr?.*Man?))",
+        testament: "",
+        chapters: [15],
+      ),
+      Book.new(
+        id: 119,
+        name: "Additional Psalm",
+        abbreviation: "Add Ps",
+        regex: "(?:(Add.*Ps))",
+        testament: "",
+        chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
+      ),
+      Book.new(
+        id: 120,
+        name: "Ode",
+        abbreviation: "Ode",
+        regex: "Ode",
+        testament: "",
+        chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
+      ),
+    ]
+
     def self.books
-      @@books
+      if BibleBot.include_deuterocanonical_content?
+        @@books + @@deuterocanonical_books
+      else
+        @@books
+      end
     end
 
     # assemble the book regex
@@ -563,6 +731,12 @@ module BibleBot
            '(?:\s*[:\.]\s*)?' +
            '(?<EndVerseNumber>\d{1,3})?' +
          ')?', book_re_string, book_re_string), Regexp::IGNORECASE)
+    end
+
+    def self.reset_regular_expressions
+      @@book_re_string = nil
+      @@book_re = nil
+      @@scripture_re = nil
     end
   end
 end

--- a/lib/bible_bot/version.rb
+++ b/lib/bible_bot/version.rb
@@ -1,3 +1,3 @@
 module BibleBot
-  VERSION = "2.0.2"
+  VERSION = "2.1.0"
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe BibleBot do
+
+  describe "scan with deuterocanonical content enabled" do
+    before(:each) do
+      BibleBot.include_deuterocanonical_content = true
+    end
+
+    it "has a config" do
+      expect(BibleBot.include_deuterocanonical_content?).to eq true
+    end
+
+    test_cases = [
+      {ref: "Tob 1:1", expected: ["Tobit 1:1"]},
+      {ref: "Ode 151:2", expected: ["Ode 151:2"]},
+    ]
+
+    test_cases.each do |t|
+      it "Can parse \"#{t[:ref]}\"" do
+
+        expect( ReferenceMatch.scan( t[:ref] ).map {|rm| rm.reference.formatted }).to eq t[:expected]
+      end
+
+      it "Can parse \"giberish 84 #{t[:ref]} foo bar\"" do
+        BibleBot.include_deuterocanonical_content = true
+        expect( ReferenceMatch.scan( "giberish 84 #{t[:ref]} foo bar" ).map {|rm| rm.reference.formatted }).to eq t[:expected]
+      end
+    end
+  end
+
+  describe "scan with deuterocanonical content disabled" do
+    before(:each) do
+      BibleBot.include_deuterocanonical_content = false
+    end
+
+    it "has a config" do
+      expect(BibleBot.include_deuterocanonical_content?).to eq false
+    end
+
+    test_cases = [
+      {ref: "John 1:1", expected: ["John 1:1"]},
+      {ref: "Tob 1:1", expected: []},
+      {ref: "Ode 151:2", expected: []},
+    ]
+
+    test_cases.each do |t|
+      it "Can parse \"#{t[:ref]}\"" do
+        expect( ReferenceMatch.scan( t[:ref] ).map {|rm| rm.reference.formatted }).to eq t[:expected]
+      end
+
+      it "Can parse \"giberish 84 #{t[:ref]} foo bar\"" do
+        expect( ReferenceMatch.scan( "giberish 84 #{t[:ref]} foo bar" ).map {|rm| rm.reference.formatted }).to eq t[:expected]
+      end
+    end
+  end
+end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -13,6 +13,8 @@ describe BibleBot do
 
     test_cases = [
       {ref: "Tob 1:1", expected: ["Tobit 1:1"]},
+      {ref: "Judith 1:2", expected: ["Judith 1:2"]},
+      {ref: "Ecclus 1:8", expected: ["Ecclesiasticus 1:8"]},
       {ref: "Ode 151:2", expected: ["Ode 151:2"]},
     ]
 


### PR DESCRIPTION
```ruby

BibleBot.include_deuterocanonical_content = true

ReferenceMatch.scan( "Tob 1:1" ).map {|rm| rm.reference.formatted}

# > ["Tobit 1:1"]

```