### PR TITLE
Support Apocryphal books per the Oxford Annotated Bible

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [ '3.0', '3.1', '3.2' ]
+        ruby-version: [ '3.1', '3.2' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem 'rspec', '~> 3.5.0'
 gem 'guard'
 gem 'guard-rspec', require: false
+gem 'debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.3)
+    debug (1.9.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.3)
     ffi (1.16.3)
     formatador (1.1.0)
@@ -24,6 +27,10 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    io-console (0.7.2)
+    irb (1.11.1)
+      rdoc
+      reline (>= 0.4.2)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -36,9 +43,15 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    psych (5.1.2)
+      stringio
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rdoc (6.6.2)
+      psych (>= 4.0.0)
+    reline (0.4.2)
+      io-console (~> 0.5)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -53,6 +66,7 @@ GEM
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
     shellany (0.0.1)
+    stringio (3.1.0)
     thor (1.3.0)
 
 PLATFORMS
@@ -60,6 +74,7 @@ PLATFORMS
 
 DEPENDENCIES
   bible_bot!
+  debug
   guard
   guard-rspec
   rspec (~> 3.5.0)

--- a/README.md
+++ b/README.md
@@ -133,19 +133,19 @@ verse == other_verse
 verse > other_verse
 ```
 
-## Deuterocanonical References
+## Apocryphal References
 
-If you want to match deuterocanonical references in your strings, you can enable a collection of matchers like this:
+If you want to match apocryphal references in your strings, you can enable a collection of matchers like this:
 
 ```ruby
-BibleBot.include_deuterocanonical_content = true
+BibleBot.include_apocryphal_content = true
 
 ReferenceMatch.scan( "Tob 1:1" ).first.reference.formatted
 
 # > "Tobit 1:1"
 ```
 
-You can see the supported deuterocanonical works in [bible.rb](https://github.com/LittleLea/bible_bot/blob/b94fe9b3948ceb23d39961ffdc4bdf7ffe23eff3/lib/bible_bot/bible.rb#L537)
+You can see the supported apocryphal works in [bible.rb](https://github.com/LittleLea/bible_bot/blob/b94fe9b3948ceb23d39961ffdc4bdf7ffe23eff3/lib/bible_bot/bible.rb#L537)
 
 ## History
 

--- a/bible_bot.gemspec
+++ b/bible_bot.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/lightstock/bible_bot"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.files         = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH)
   spec.bindir        = 'exe'

--- a/bible_bot.gemspec
+++ b/bible_bot.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/lightstock/bible_bot"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 3.0'
+
   spec.files         = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH)
   spec.bindir        = 'exe'
   spec.executables   = []

--- a/lib/bible_bot.rb
+++ b/lib/bible_bot.rb
@@ -10,7 +10,7 @@ require "bible_bot/references"
 
 module BibleBot
   DEFAULTS = {
-    include_deuterocanonical_content: false
+    include_apocryphal_content: false
   }
 
   def self.options
@@ -25,18 +25,18 @@ module BibleBot
   # Configuration for BibleBot, use like:
   #
   #   BibleBot.configure do |config|
-  #     config.include_deuterocanonical_content = true
+  #     config.include_apocryphal_content = true
   #   end
   def self.configure
     yield(options)
   end
 
-  def self.include_deuterocanonical_content?
-    !!self.options.include_deuterocanonical_content
+  def self.include_apocryphal_content?
+    !!self.options.include_apocryphal_content
   end
 
-  def self.include_deuterocanonical_content=(inc)
-    self.options.include_deuterocanonical_content = (inc == true)
+  def self.include_apocryphal_content=(inc)
+    self.options.include_apocryphal_content = (inc == true)
 
     # We need to reset the stored regexps because they take content into account.
     BibleBot::Bible.reset_regular_expressions

--- a/lib/bible_bot/bible.rb
+++ b/lib/bible_bot/bible.rb
@@ -607,7 +607,7 @@ module BibleBot
         name: "Tobit",
         abbreviation: "Tob",
         dbl_code: "TOB",
-        regex: "Tob(?:it)?",
+        regex: "(?:(Tb|Tob|Tobit))",
         testament: "Apocrypha",
         chapters: [22, 14, 17, 21, 22, 18, 17, 21, 6, 14, 18, 22, 18, 15],
       ),
@@ -616,7 +616,7 @@ module BibleBot
         name: "Judith",
         abbreviation: "Jth",
         dbl_code: "JDT",
-        regex: "(?:Ju?d?i?th?)",
+        regex: "(?:(Jdt|Jth|Jdth|Judith))",
         testament: "Apocrypha",
         chapters: [16, 28, 10, 15, 24, 21, 32, 36, 14, 23, 23, 20, 20, 19, 14, 25],
       ),
@@ -625,7 +625,7 @@ module BibleBot
         name: "Additions to Esther",
         abbreviation: "Add Esth",
         dbl_code: "ESG",
-        regex: "(?:((Add\s?|(The\s)?Rest\sof\s|A))Est?h?e?r?)",
+        regex: "(?:(Add(itions)?(\\sto)?|(The\\s)?Rest\\sof|A)\\s*Est?h?e?r?)",
         testament: "Apocrypha",
         chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 8, 30, 16, 24, 10],
       ),
@@ -634,7 +634,7 @@ module BibleBot
         name: "Wisdom of Solomon",
         abbreviation: "Wis",
         dbl_code: "WIS",
-        regex: "(?:(Wi?sd?\.?(\sof\s)?(Sol|om)?))",
+        regex: "(?:(Wi?sd?(om)?(\\sof\\s)?(Sol|Solomon)?))",
         testament: "Apocrypha",
         chapters: [16, 24, 19, 20, 23, 25, 30, 21, 18, 21, 26, 27, 19, 31, 19, 29, 21, 25, 22],
       ),
@@ -652,7 +652,7 @@ module BibleBot
         name: "Baruch",
         abbreviation: "Bar",
         dbl_code: "BAR",
-        regex: "Bar(?:uch)?",
+        regex: "(?:Bar(?:uch)?)",
         testament: "Apocrypha",
         chapters: [22, 35, 38, 37, 9, 72],
       ),
@@ -661,7 +661,7 @@ module BibleBot
         name: "Letter of Jeremiah", # Often placed as Baruch 6, but sometimes stands alone
         abbreviation: "Ep Jer",
         dbl_code: "LJE",
-        regex: "(?:((Le?t?t?e?r?|Ep)(\.\s|\sof\s)?Jer?))",
+        regex: "(?:(Letter of Jeremiah|Ep Jer|Let Jer|Ltr Jer|LJe))",
         testament: "Apocrypha",
         chapters: [73],
       ),
@@ -670,7 +670,7 @@ module BibleBot
         name: "Prayer of Azariah and the Song of the Three Jews", # An extension of Daniel 3... a.k.a. Prayer of Azariah
         abbreviation: "Sg of 3 Childr",
         dbl_code: "S3Y",
-        regex: "(?:(((The\s)?(So?n?g)(\.?\s?o?f?\s?)(the\s)?(3|Thr).*))|((Pr)?.*Aza?r?))",
+        regex: "(?:(?:Pr\\sAz|Prayer\\sof\\sAzariah|Azariah|(?:The\\s)?So?n?g\\s(?:of\\s)?(?:the\\s)?(?:3|Three|Thr)(?:\\s(?:Holy|Young)?\\s*(?:Childr(?:en)?|Jews))?))",
         testament: "Apocrypha",
         chapters: [68],
       ),
@@ -679,7 +679,7 @@ module BibleBot
         name: "Susanna", # A book of Daniel
         abbreviation: "Sus",
         dbl_code: "SUS",
-        regex: "(?:(Sus))",
+        regex: "(?:Sus(?:anna)?)",
         testament: "Apocrypha",
         chapters: [64],
       ),
@@ -688,7 +688,7 @@ module BibleBot
         name: "Bel and the Dragon", # A book of Daniel
         abbreviation: "Bel and Dr",
         dbl_code: "BEL",
-        regex: "(?:(Bel))",
+        regex: "(?:Bel(\\s(and\\sthe\\sDragon|and\\sDr))?)",
         testament: "Apocrypha",
         chapters: [42],
       ),
@@ -697,7 +697,7 @@ module BibleBot
         name: "1 Maccabees",
         abbreviation: "1 Macc",
         dbl_code: "1MA",
-        regex: "(?:1|I)(?:\\s)?Macc(?:abees)?",
+        regex: "(?:(1|1st|I|First)\\s*(M|Ma|Mac|Macc|Maccabees))",
         testament: "Apocrypha",
         chapters: [63, 70, 59, 61, 68, 63, 50, 32, 73, 89, 74, 53, 53, 49, 41, 24],
       ),
@@ -706,7 +706,7 @@ module BibleBot
         name: "2 Maccabees",
         abbreviation: "2 Macc",
         dbl_code: "2MA",
-        regex: "(?:((2n?d?|^I{2}|Second)\s?Ma?c?))",
+        regex: "(?:(2|2nd|II|Second)\\s*(M|Ma|Mac|Macc|Maccabees))",
         testament: "Apocrypha",
         chapters: [36, 32, 40, 50, 27, 31, 42, 36, 29, 38, 38, 46, 26, 46, 39],
       ),
@@ -715,7 +715,7 @@ module BibleBot
         name: "1 Esdras",
         abbreviation: "1 Esd",
         dbl_code: "1ES",
-        regex: "(?:((1s?t?|^I{1}|First)\s?Esd?))",
+        regex: "(?:(1|1st|I|First)\\s*(Esd|Esdr|Esdras))",
         testament: "Apocrypha",
         chapters: [58, 30, 24, 63, 73, 34, 15, 96, 55],
       ),
@@ -724,25 +724,25 @@ module BibleBot
         name: "Prayer of Manasseh",
         abbreviation: "Pr of Man",
         dbl_code: "MAN",
-        regex: "(?:(Pr?.*Man?))",
+        regex: "(?:(Prayer\\sof\\sManasseh|Pr\\sof\\sMan|PMa|Prayer\\sof\\sManasses))",
         testament: "Apocrypha",
         chapters: [15],
       ),
       Book.new(
         id: 115,
-        name: "Additional Psalm", # Psalm 151
-        abbreviation: "Add Ps",
+        name: "Psalm 151",
+        abbreviation: "Psalm 151",
         dbl_code: "PS2",
-        regex: "(?:(Add.*Ps))",
+        regex: "(?:Ps(?:alms|alm|s|m|a)?\\s151)",
         testament: "Apocrypha",
-        chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
+        chapters: [7],
       ),
       Book.new(
         id: 116,
         name: "3 Maccabees",
         abbreviation: "3 Macc",
         dbl_code: "3MA",
-        regex: "(?:((3r?d?|^I{3}|Third)\s?Ma?c?))",
+        regex: "(?:(3|3rd|III|Third)\\s*(M|Ma|Mac|Macc|Maccabees))",
         testament: "Apocrypha",
         chapters: [29, 33, 30, 21, 51, 41, 23],
       ),
@@ -751,7 +751,7 @@ module BibleBot
         name: "2 Esdras",
         abbreviation: "2 Esd",
         dbl_code: "2ES",
-        regex: "(?:((2n?d?|^I{2}|Second)\s?Esd?))",
+        regex: "(?:(2|2nd|II|Second)\\s*(Esd|Esdr|Esdras))",
         testament: "Apocrypha",
         chapters: [40, 48, 36, 52, 56, 59, 140, 63, 47, 59, 46, 51, 58, 48, 63, 78],
       ),
@@ -760,7 +760,7 @@ module BibleBot
         name: "4 Maccabees",
         abbreviation: "4 Macc",
         dbl_code: "4MA",
-        regex: "(?:((4t?h?|IV|Fourth)\s?Ma?c?))",
+        regex: "(?:(4|4th|IV|Fourth)\\s*(M|Ma|Mac|Macc|Maccabees))",
         testament: "Apocrypha",
         chapters: [35, 24, 21, 26, 38, 35, 23, 29, 32, 21, 27, 19, 27, 20, 32, 25, 24, 24],
       ),
@@ -768,7 +768,9 @@ module BibleBot
 
     def self.books
       if BibleBot.include_apocryphal_content?
-        @@books + @@apocryphal_books
+        # Apocryphal books have to come first, since there's some overlap in the regex, but
+        # the apocryphal books are more verbose. "Song", "Esther", "Psalm"
+        @@apocryphal_books + @@books
       else
         @@books
       end

--- a/lib/bible_bot/bible.rb
+++ b/lib/bible_bot/bible.rb
@@ -601,7 +601,7 @@ module BibleBot
       )
     ]
 
-    @@deuterocanonical_books = [
+    @@apocryphal_books = [
       Book.new(
         id: 101,
         name: "Tobit",
@@ -777,8 +777,8 @@ module BibleBot
     ]
 
     def self.books
-      if BibleBot.include_deuterocanonical_content?
-        @@books + @@deuterocanonical_books
+      if BibleBot.include_apocryphal_content?
+        @@books + @@apocryphal_books
       else
         @@books
       end

--- a/lib/bible_bot/bible.rb
+++ b/lib/bible_bot/bible.rb
@@ -608,7 +608,7 @@ module BibleBot
         abbreviation: "Tob",
         dbl_code: "TOB",
         regex: "Tob(?:it)?",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [22, 14, 17, 21, 22, 18, 17, 21, 6, 14, 18, 22, 18, 15],
       ),
       Book.new(
@@ -617,7 +617,7 @@ module BibleBot
         abbreviation: "Jth",
         dbl_code: "JDT",
         regex: "(?:Ju?d?i?th?)",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [16, 28, 10, 15, 24, 21, 32, 36, 14, 23, 23, 20, 20, 19, 14, 25],
       ),
       Book.new(
@@ -626,7 +626,7 @@ module BibleBot
         abbreviation: "Add Esth",
         dbl_code: "ESG",
         regex: "(?:((Add\s?|(The\s)?Rest\sof\s|A))Est?h?e?r?)",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 8, 30, 16, 24, 10],
       ),
       Book.new(
@@ -635,7 +635,7 @@ module BibleBot
         abbreviation: "Wis",
         dbl_code: "WIS",
         regex: "(?:(Wi?sd?\.?(\sof\s)?(Sol|om)?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [16, 24, 19, 20, 23, 25, 30, 21, 18, 21, 26, 27, 19, 31, 19, 29, 21, 25, 22],
       ),
       Book.new(
@@ -644,7 +644,7 @@ module BibleBot
         abbreviation: "Sir",
         dbl_code: "SIR",
         regex: "(?:(Sir(?:ach)?)|Ecclus|Ecclesiasticus)",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [29, 18, 30, 31, 17, 37, 36, 19, 18, 30, 34, 18, 25, 27, 20, 28, 27, 33, 26, 30, 28, 27, 27, 31, 25, 20, 30, 26, 28, 25, 31, 24, 33, 26, 24, 27, 30, 34, 35, 30, 24, 25, 35, 23, 26, 20, 25, 25, 16, 29, 30],
       ),
       Book.new(
@@ -653,7 +653,7 @@ module BibleBot
         abbreviation: "Bar",
         dbl_code: "BAR",
         regex: "Bar(?:uch)?",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [22, 35, 38, 37, 9, 72],
       ),
       Book.new(
@@ -662,7 +662,7 @@ module BibleBot
         abbreviation: "Ep Jer",
         dbl_code: "LJE",
         regex: "(?:((Le?t?t?e?r?|Ep)(\.\s|\sof\s)?Jer?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [73],
       ),
       Book.new(
@@ -671,7 +671,7 @@ module BibleBot
         abbreviation: "Sg of 3 Childr",
         dbl_code: "S3Y",
         regex: "(?:(((The\s)?(So?n?g)(\.?\s?o?f?\s?)(the\s)?(3|Thr).*))|((Pr)?.*Aza?r?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [],
       ),
       Book.new(
@@ -680,7 +680,7 @@ module BibleBot
         abbreviation: "Sus",
         dbl_code: "SUS",
         regex: "(?:(Sus))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [64],
       ),
       Book.new(
@@ -689,7 +689,7 @@ module BibleBot
         abbreviation: "Bel and Dr",
         dbl_code: "BEL",
         regex: "(?:(Bel))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [42],
       ),
       Book.new(
@@ -699,7 +699,7 @@ module BibleBot
         dbl_code: "1MA",
         #regex: "(?:((1s?t?|^I{1}|First)\s?Ma?c?))",
         regex: "(?:1|I)(?:\\s)?Macc(?:abees)?",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [63, 70, 59, 61, 68, 63, 50, 32, 73, 89, 74, 53, 53, 49, 41, 24],
       ),
       Book.new(
@@ -708,7 +708,7 @@ module BibleBot
         abbreviation: "2 Macc",
         dbl_code: "2MA",
         regex: "(?:((2n?d?|^I{2}|Second)\s?Ma?c?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [36, 32, 40, 50, 27, 31, 42, 36, 29, 38, 38, 46, 26, 46, 39],
       ),
       Book.new(
@@ -717,7 +717,7 @@ module BibleBot
         abbreviation: "3 Macc",
         dbl_code: "3MA",
         regex: "(?:((3r?d?|^I{3}|Third)\s?Ma?c?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [29, 33, 30, 21, 51, 41, 23],
       ),
       Book.new(
@@ -726,7 +726,7 @@ module BibleBot
         abbreviation: "4 Macc",
         dbl_code: "4MA",
         regex: "(?:((4t?h?|IV|Fourth)\s?Ma?c?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [35, 24, 21, 26, 38, 35, 23, 29, 32, 21, 27, 19, 27, 20, 32, 25, 24, 24],
       ),
       Book.new(
@@ -735,7 +735,7 @@ module BibleBot
         abbreviation: "1 Esd",
         dbl_code: "1ES",
         regex: "(?:((1s?t?|^I{1}|First)\s?Esd?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [58, 30, 24, 63, 73, 34, 15, 96, 55],
       ),
       Book.new(
@@ -744,7 +744,7 @@ module BibleBot
         abbreviation: "2 Esd",
         dbl_code: "2ES",
         regex: "(?:((2n?d?|^I{2}|Second)\s?Esd?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [40, 48, 36, 52, 56, 59, 140, 63, 47, 59, 46, 51, 58, 48, 63, 78],
       ),
       Book.new(
@@ -753,7 +753,7 @@ module BibleBot
         abbreviation: "Pr of Man",
         dbl_code: "MAN",
         regex: "(?:(Pr?.*Man?))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [15],
       ),
       Book.new(
@@ -762,7 +762,7 @@ module BibleBot
         abbreviation: "Add Ps",
         dbl_code: "PS2",
         regex: "(?:(Add.*Ps))",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
       ),
       Book.new(
@@ -771,7 +771,7 @@ module BibleBot
         abbreviation: "Ode",
         dbl_code: "ODA",
         regex: "Ode",
-        testament: "",
+        testament: "Apocrypha",
         chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
       ),
     ]

--- a/lib/bible_bot/bible.rb
+++ b/lib/bible_bot/bible.rb
@@ -640,7 +640,7 @@ module BibleBot
       ),
       Book.new(
         id: 105,
-        name: "Sirach (Ecclesiasticus)", # a.k.a. Ecclesiasticus
+        name: "Sirach", # a.k.a. Ecclesiasticus
         abbreviation: "Sir",
         dbl_code: "SIR",
         regex: "(?:(Sir(?:ach)?)|Ecclus|Ecclesiasticus)",
@@ -667,12 +667,12 @@ module BibleBot
       ),
       Book.new(
         id: 108,
-        name: "Song of Three Youths", # An extension of Daniel 3... a.k.a. Prayer of Azariah
+        name: "Prayer of Azariah and the Song of the Three Jews", # An extension of Daniel 3... a.k.a. Prayer of Azariah
         abbreviation: "Sg of 3 Childr",
         dbl_code: "S3Y",
         regex: "(?:(((The\s)?(So?n?g)(\.?\s?o?f?\s?)(the\s)?(3|Thr).*))|((Pr)?.*Aza?r?))",
         testament: "Apocrypha",
-        chapters: [],
+        chapters: [68],
       ),
       Book.new(
         id: 109,
@@ -697,7 +697,6 @@ module BibleBot
         name: "1 Maccabees",
         abbreviation: "1 Macc",
         dbl_code: "1MA",
-        #regex: "(?:((1s?t?|^I{1}|First)\s?Ma?c?))",
         regex: "(?:1|I)(?:\\s)?Macc(?:abees)?",
         testament: "Apocrypha",
         chapters: [63, 70, 59, 61, 68, 63, 50, 32, 73, 89, 74, 53, 53, 49, 41, 24],
@@ -713,24 +712,6 @@ module BibleBot
       ),
       Book.new(
         id: 113,
-        name: "3 Maccabees",
-        abbreviation: "3 Macc",
-        dbl_code: "3MA",
-        regex: "(?:((3r?d?|^I{3}|Third)\s?Ma?c?))",
-        testament: "Apocrypha",
-        chapters: [29, 33, 30, 21, 51, 41, 23],
-      ),
-      Book.new(
-        id: 114,
-        name: "4 Maccabees",
-        abbreviation: "4 Macc",
-        dbl_code: "4MA",
-        regex: "(?:((4t?h?|IV|Fourth)\s?Ma?c?))",
-        testament: "Apocrypha",
-        chapters: [35, 24, 21, 26, 38, 35, 23, 29, 32, 21, 27, 19, 27, 20, 32, 25, 24, 24],
-      ),
-      Book.new(
-        id: 115,
         name: "1 Esdras",
         abbreviation: "1 Esd",
         dbl_code: "1ES",
@@ -739,16 +720,7 @@ module BibleBot
         chapters: [58, 30, 24, 63, 73, 34, 15, 96, 55],
       ),
       Book.new(
-        id: 116,
-        name: "2 Esdras",
-        abbreviation: "2 Esd",
-        dbl_code: "2ES",
-        regex: "(?:((2n?d?|^I{2}|Second)\s?Esd?))",
-        testament: "Apocrypha",
-        chapters: [40, 48, 36, 52, 56, 59, 140, 63, 47, 59, 46, 51, 58, 48, 63, 78],
-      ),
-      Book.new(
-        id: 117,
+        id: 114,
         name: "Prayer of Manasseh",
         abbreviation: "Pr of Man",
         dbl_code: "MAN",
@@ -757,8 +729,8 @@ module BibleBot
         chapters: [15],
       ),
       Book.new(
-        id: 118,
-        name: "Additional Psalm",
+        id: 115,
+        name: "Additional Psalm", # Psalm 151
         abbreviation: "Add Ps",
         dbl_code: "PS2",
         regex: "(?:(Add.*Ps))",
@@ -766,13 +738,31 @@ module BibleBot
         chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
       ),
       Book.new(
-        id: 119,
-        name: "Ode",
-        abbreviation: "Ode",
-        dbl_code: "ODA",
-        regex: "Ode",
+        id: 116,
+        name: "3 Maccabees",
+        abbreviation: "3 Macc",
+        dbl_code: "3MA",
+        regex: "(?:((3r?d?|^I{3}|Third)\s?Ma?c?))",
         testament: "Apocrypha",
-        chapters: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7],
+        chapters: [29, 33, 30, 21, 51, 41, 23],
+      ),
+      Book.new(
+        id: 117,
+        name: "2 Esdras",
+        abbreviation: "2 Esd",
+        dbl_code: "2ES",
+        regex: "(?:((2n?d?|^I{2}|Second)\s?Esd?))",
+        testament: "Apocrypha",
+        chapters: [40, 48, 36, 52, 56, 59, 140, 63, 47, 59, 46, 51, 58, 48, 63, 78],
+      ),
+      Book.new(
+        id: 118,
+        name: "4 Maccabees",
+        abbreviation: "4 Macc",
+        dbl_code: "4MA",
+        regex: "(?:((4t?h?|IV|Fourth)\s?Ma?c?))",
+        testament: "Apocrypha",
+        chapters: [35, 24, 21, 26, 38, 35, 23, 29, 32, 21, 27, 19, 27, 20, 32, 25, 24, 24],
       ),
     ]
 

--- a/lib/bible_bot/book.rb
+++ b/lib/bible_bot/book.rb
@@ -45,7 +45,7 @@ module BibleBot
       Bible.books.find { |book| book.id == id }
     end
 
-    def initialize(id:, name:, abbreviation:, dbl_code:, regex:, chapters: [] , testament:)
+    def initialize(id:, name:, abbreviation:, dbl_code:, regex:, testament:, chapters: [])
       @id = id
       @name = name
       @abbreviation = abbreviation

--- a/lib/bible_bot/book.rb
+++ b/lib/bible_bot/book.rb
@@ -1,9 +1,23 @@
+# frozen_string_literal: true
+
 module BibleBot
-  # Represents one of the 66 books in the bible (Genesis - Revelation).
+  # Represents one of the 66 books in the bible (Genesis - Revelation) or Apocryphal books.
   # You should never need to initialize a Book, they are initialized in {Bible}.
   class Book
     NULL = Object.new.freeze
     private_constant :NULL
+
+    APOCRYPHA = 'Apocrypha'
+    private_constant :APOCRYPHA
+
+    NEW_TESTAMENT = 'New'
+    private_constant :NEW_TESTAMENT
+
+    OLD_TESTAMENT = 'Old'
+    private_constant :OLD_TESTAMENT
+
+    TESTAMENTS = [OLD_TESTAMENT, NEW_TESTAMENT, APOCRYPHA].freeze
+    private_constant :TESTAMENTS
 
     attr_reader :id # @return [Integer]
     attr_reader :name # @return [String]
@@ -46,6 +60,8 @@ module BibleBot
     end
 
     def initialize(id:, name:, abbreviation:, dbl_code:, regex:, testament:, chapters: [])
+      raise "Unknown testament: #{testament.inspect}" unless TESTAMENTS.include?(testament)
+
       @id = id
       @name = name
       @abbreviation = abbreviation
@@ -58,6 +74,13 @@ module BibleBot
       @first_verse = nil
       @last_verse = nil
       @next_book = NULL
+      @apocryphal = testament == APOCRYPHA
+    end
+
+    # Whether or not the book is one of the original 66
+    # @return [Boolean]
+    def apocryphal?
+      @apocryphal
     end
 
     # @return [String]

--- a/spec/lib/book_spec.rb
+++ b/spec/lib/book_spec.rb
@@ -82,4 +82,34 @@ describe BibleBot::Book do
       expect(book.reference.inspect).to include(start_verse: "1 John 1:1", end_verse: "1 John 5:21")
     end
   end
+
+  describe "apocryphal?" do
+    subject { book.apocryphal? }
+
+    let(:book) do
+      BibleBot::Book.new(
+        id: 999,
+        name: 'Foo',
+        abbreviation: 'Foo',
+        dbl_code: 'FOO',
+        regex: 'foo',
+        testament:
+      )
+    end
+
+    context 'when old testament' do
+      let(:testament) { 'Old' }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when new testament' do
+      let(:testament) { 'New' }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when apocryphal' do
+      let(:testament) { 'Apocrypha' }
+      it { is_expected.to eq(true) }
+    end
+  end
 end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -12,20 +12,157 @@ describe BibleBot do
     end
 
     test_cases = [
+      {ref: "Tobit 1:1", expected: ["Tobit 1:1"]},
       {ref: "Tob 1:1", expected: ["Tobit 1:1"]},
+      {ref: "Tb 1:1", expected: ["Tobit 1:1"]},
+
       {ref: "Judith 1:2", expected: ["Judith 1:2"]},
+      {ref: "Jth 1:2", expected: ["Judith 1:2"]},
+      {ref: "Jdth 1:2", expected: ["Judith 1:2"]},
+      {ref: "Jdt 1:2", expected: ["Judith 1:2"]},
+
+      {ref: "Additions to Esther 1:2", expected: ["Additions to Esther 1:2"]},
+      {ref: "Add Esth 1:2", expected: ["Additions to Esther 1:2"]},
+      {ref: "Add Es 1:2", expected: ["Additions to Esther 1:2"]},
+      {ref: "Rest of Esther 1:2", expected: ["Additions to Esther 1:2"]},
+      {ref: "The Rest of Esther 1:2", expected: ["Additions to Esther 1:2"]},
+      {ref: "AEs 1:2", expected: ["Additions to Esther 1:2"]},
+      {ref: "AddEsth 1:2", expected: ["Additions to Esther 1:2"]},
+
+      {ref: "Wisdom of Solomon 1:2", expected: ["Wisdom of Solomon 1:2"]},
+      {ref: "Wis of Sol 1:2", expected: ["Wisdom of Solomon 1:2"]},
+      {ref: "Wis 1:2", expected: ["Wisdom of Solomon 1:2"]},
+      {ref: "Ws 1:2", expected: ["Wisdom of Solomon 1:2"]},
+
+      {ref: "Sirach 1:8", expected: ["Sirach 1:8"]},
+      {ref: "Sir 1:8", expected: ["Sirach 1:8"]},
       {ref: "Ecclus 1:8", expected: ["Sirach 1:8"]},
-      {ref: "Ps 151:2", expected: ["Psalm 151:2"]},
+      {ref: "Ecclesiasticus 1:8", expected: ["Sirach 1:8"]},
+
+      {ref: "Baruch 1:3", expected: ["Baruch 1:3"]},
+      {ref: "Bar 1:3", expected: ["Baruch 1:3"]},
+
+      {ref: "Letter of Jeremiah 1:3", expected: ["Letter of Jeremiah 1:3"]},
+      {ref: "Ep Jer 1:3", expected: ["Letter of Jeremiah 1:3"]},
+      {ref: "Let Jer 1:3", expected: ["Letter of Jeremiah 1:3"]},
+      {ref: "Ltr Jer 1:3", expected: ["Letter of Jeremiah 1:3"]},
+      {ref: "LJe 1:3", expected: ["Letter of Jeremiah 1:3"]},
+
+      {ref: "Prayer of Azariah and the Song of the Three Jews 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Sg of 3 Childr 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Song of Three 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Song of Thr 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Song Thr 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Song of the Three Holy Children 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Song of Three Children 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "The Song of Three Jews 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Song of Three Jews 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Prayer of Azariah 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Azariah 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+      {ref: "Pr Az 1:1", expected: ["Prayer of Azariah and the Song of the Three Jews 1:1"]},
+
+      {ref: "Susanna 1:1", expected: ["Susanna 1:1"]},
+      {ref: "Sus 1:1", expected: ["Susanna 1:1"]},
+
+      {ref: "Bel and the Dragon 1:1", expected: ["Bel and the Dragon 1:1"]},
+      {ref: "Bel and Dr 1:1", expected: ["Bel and the Dragon 1:1"]},
+      {ref: "Bel 1:1", expected: ["Bel and the Dragon 1:1"]},
+
+      {ref: "1 Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "1 Mac 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "1Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "1Macc 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "1Ma 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "1M 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "I Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "I Macc 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "I Mac 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "I Ma 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "1st Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "First Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
+
+      {ref: "2 Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "2 Mac 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "2Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "2Macc 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "2Ma 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "2M 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "II Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "II Macc 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "II Mac 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "II Ma 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "2nd Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "Second Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
+
+      {ref: "1 Esdras 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "1 Esdr 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "1 Esd 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "1Esdras 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "1Esdr 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "1Esd 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "I Esdras 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "I Esdr 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "I Esd 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "1st Esdras 1:1", expected: ["1 Esdras 1:1"]},
+      {ref: "First Esdras 1:1", expected: ["1 Esdras 1:1"]},
+
+      {ref: "Prayer of Manasseh 1:1", expected: ["Prayer of Manasseh 1:1"]},
+      {ref: "Pr of Man 1:1", expected: ["Prayer of Manasseh 1:1"]},
+      {ref: "PMa 1:1", expected: ["Prayer of Manasseh 1:1"]},
+      {ref: "Prayer of Manasses 1:1", expected: ["Prayer of Manasseh 1:1"]},
+
+      {ref: "Psalms 151 1:1", expected: ["Psalm 151 1:1"]},
+      {ref: "Psalm 151 1:1", expected: ["Psalm 151 1:1"]},
+      {ref: "Psa 151 1:1", expected: ["Psalm 151 1:1"]},
+      {ref: "Psm 151 1:1", expected: ["Psalm 151 1:1"]},
+      {ref: "Pss 151 1:1", expected: ["Psalm 151 1:1"]},
+      {ref: "Ps 151 1:1", expected: ["Psalm 151 1:1"]},
+
+      {ref: "3 Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "3 Mac 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "3Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "3Macc 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "3Ma 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "3M 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "III Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "III Macc 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "III Mac 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "III Ma 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "3rd Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "Third Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
+
+      {ref: "2 Esdras 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "2 Esdr 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "2 Esd 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "2Esdras 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "2Esdr 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "2Esd 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "II Esdras 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "II Esdr 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "II Esd 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "2nd Esdras 1:1", expected: ["2 Esdras 1:1"]},
+      {ref: "Second Esdras 1:1", expected: ["2 Esdras 1:1"]},
+
+      {ref: "4 Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "4 Mac 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "4Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "4Macc 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "4Ma 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "4M 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "IV Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "IV Macc 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "IV Mac 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "IV Ma 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "4th Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "Fourth Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
     ]
 
     test_cases.each do |t|
       it "Can parse \"#{t[:ref]}\"" do
-
         expect( ReferenceMatch.scan( t[:ref] ).map {|rm| rm.reference.formatted }).to eq t[:expected]
       end
 
       it "Can parse \"giberish 84 #{t[:ref]} foo bar\"" do
-        BibleBot.include_apocryphal_content = true
         expect( ReferenceMatch.scan( "giberish 84 #{t[:ref]} foo bar" ).map {|rm| rm.reference.formatted }).to eq t[:expected]
       end
     end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe BibleBot do
 
-  describe "scan with deuterocanonical content enabled" do
+  describe "scan with apocryphal content enabled" do
     before(:each) do
-      BibleBot.include_deuterocanonical_content = true
+      BibleBot.include_apocryphal_content = true
     end
 
     it "has a config" do
-      expect(BibleBot.include_deuterocanonical_content?).to eq true
+      expect(BibleBot.include_apocryphal_content?).to eq true
     end
 
     test_cases = [
@@ -25,19 +25,19 @@ describe BibleBot do
       end
 
       it "Can parse \"giberish 84 #{t[:ref]} foo bar\"" do
-        BibleBot.include_deuterocanonical_content = true
+        BibleBot.include_apocryphal_content = true
         expect( ReferenceMatch.scan( "giberish 84 #{t[:ref]} foo bar" ).map {|rm| rm.reference.formatted }).to eq t[:expected]
       end
     end
   end
 
-  describe "scan with deuterocanonical content disabled" do
+  describe "scan with apocryphal content disabled" do
     before(:each) do
-      BibleBot.include_deuterocanonical_content = false
+      BibleBot.include_apocryphal_content = false
     end
 
     it "has a config" do
-      expect(BibleBot.include_deuterocanonical_content?).to eq false
+      expect(BibleBot.include_apocryphal_content?).to eq false
     end
 
     test_cases = [

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -14,8 +14,8 @@ describe BibleBot do
     test_cases = [
       {ref: "Tob 1:1", expected: ["Tobit 1:1"]},
       {ref: "Judith 1:2", expected: ["Judith 1:2"]},
-      {ref: "Ecclus 1:8", expected: ["Sirach (Ecclesiasticus) 1:8"]},
-      {ref: "Ode 151:2", expected: ["Ode 151:2"]},
+      {ref: "Ecclus 1:8", expected: ["Sirach 1:8"]},
+      {ref: "Ps 151:2", expected: ["Psalm 151:2"]},
     ]
 
     test_cases.each do |t|
@@ -43,7 +43,7 @@ describe BibleBot do
     test_cases = [
       {ref: "John 1:1", expected: ["John 1:1"]},
       {ref: "Tob 1:1", expected: []},
-      {ref: "Ode 151:2", expected: []},
+      {ref: "Ecclus 1:8", expected: []},
     ]
 
     test_cases.each do |t|


### PR DESCRIPTION
- Reorder books per Oxford's order
- Remove unintended duplicates Sirach vs Ecclesiasticus, Psalm 151 vs Ode
- Add support for common book aliases per Logos
- Add `apocryphal?` method to easily determine which books are apocryphal
- Set apocryphal testament as "Apocrypha" instead of ""
- Replace "Deuterocanonical" with "Apocryphal"