### PR TITLE
Add support for "One", "Two", "Three", and "Four" as book prefixes

### DIFF
--- a/lib/bible_bot/bible.rb
+++ b/lib/bible_bot/bible.rb
@@ -3,10 +3,10 @@
 module BibleBot
   # Defines Books and Regular Expressions used for parsing and other logic in this gem.
   class Bible
-    FIRST = %w[1 1st I First].freeze
-    SECOND = %w[2 2nd II Second].freeze
-    THIRD = %w[3 3rd III Third].freeze
-    FOURTH = %w[4 4th IV Fourth].freeze
+    FIRST = %w[1 1st I First One].freeze
+    SECOND = %w[2 2nd II Second Two].freeze
+    THIRD = %w[3 3rd III Third Three].freeze
+    FOURTH = %w[4 4th IV Fourth Four].freeze
 
     FIRST_PREFIX, SECOND_PREFIX, THIRD_PREFIX, FOURTH_PREFIX = [FIRST, SECOND, THIRD, FOURTH].map do |prefixes|
       "(?:#{prefixes.join('|')})(?:\\s)?"

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -80,6 +80,7 @@ describe BibleBot do
       {ref: "I Ma 1:1", expected: ["1 Maccabees 1:1"]},
       {ref: "1st Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
       {ref: "First Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
+      {ref: "One Maccabees 1:1", expected: ["1 Maccabees 1:1"]},
 
       {ref: "2 Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
       {ref: "2 Mac 1:1", expected: ["2 Maccabees 1:1"]},
@@ -93,6 +94,7 @@ describe BibleBot do
       {ref: "II Ma 1:1", expected: ["2 Maccabees 1:1"]},
       {ref: "2nd Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
       {ref: "Second Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
+      {ref: "Two Maccabees 1:1", expected: ["2 Maccabees 1:1"]},
 
       {ref: "1 Esdras 1:1", expected: ["1 Esdras 1:1"]},
       {ref: "1 Esdr 1:1", expected: ["1 Esdras 1:1"]},
@@ -130,6 +132,7 @@ describe BibleBot do
       {ref: "III Ma 1:1", expected: ["3 Maccabees 1:1"]},
       {ref: "3rd Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
       {ref: "Third Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
+      {ref: "Three Maccabees 1:1", expected: ["3 Maccabees 1:1"]},
 
       {ref: "2 Esdras 1:1", expected: ["2 Esdras 1:1"]},
       {ref: "2 Esdr 1:1", expected: ["2 Esdras 1:1"]},
@@ -155,6 +158,7 @@ describe BibleBot do
       {ref: "IV Ma 1:1", expected: ["4 Maccabees 1:1"]},
       {ref: "4th Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
       {ref: "Fourth Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
+      {ref: "Four Maccabees 1:1", expected: ["4 Maccabees 1:1"]},
     ]
 
     test_cases.each do |t|


### PR DESCRIPTION
ROR-388