### PR TITLE
Fix search when query includes non-English characters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ gem 'rspec', '~> 3.5.0'
 gem 'guard'
 gem 'guard-rspec', require: false
 gem 'debug'
+gem 'i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.3)
+    concurrent-ruby (1.3.4)
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -27,6 +28,8 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.11.1)
       rdoc
@@ -77,6 +80,7 @@ DEPENDENCIES
   debug
   guard
   guard-rspec
+  i18n
   rspec (~> 3.5.0)
 
 BUNDLED WITH

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,2 @@
+en:
+  this: Needs to be a hash

--- a/lib/bible_bot.rb
+++ b/lib/bible_bot.rb
@@ -7,8 +7,11 @@ require "bible_bot/verse"
 require "bible_bot/reference"
 require "bible_bot/reference_match"
 require "bible_bot/references"
+require "i18n"
 
 module BibleBot
+  I18n.load_path += Dir[File.expand_path("config/locales") + "/*.yml"]
+
   DEFAULTS = {
     include_apocryphal_content: false
   }

--- a/lib/bible_bot/book.rb
+++ b/lib/bible_bot/book.rb
@@ -34,6 +34,7 @@ module BibleBot
     def self.find_by_name(name)
       return nil if name.nil? || name.strip == ""
       name = name.tr('’', "'")
+      name = I18n.transliterate(name)
 
       Bible.books.detect { |book| book.name.casecmp?(name) || book.regex_matcher.match?(name) }
     end

--- a/lib/bible_bot/reference_match.rb
+++ b/lib/bible_bot/reference_match.rb
@@ -46,14 +46,17 @@ module BibleBot
     # @return [Array<ReferenceMatch>]
     def self.scan(text)
       # convert en dash & em dash to hyphens
-      text = text.tr("\u2013\u2014", '--') 
+      text = text.tr("\u2013\u2014", '--')
 
       # convert smart quotes to apostrophes, they cause an "invalid pattern in look-behind" error
       text = text.tr('’', "'")
 
+      # convert non-ASCII characters to their closest English equivalent
+      text = I18n.transliterate(text)
+
       # Compact consecutive spaces into 1.
       # This is necessary for negative lookup matchers, such as the one for "John".
-      text.squeeze!(' ') 
+      text.squeeze!(' ')
 
       scripture_reg = Bible.scripture_re
       Array.new.tap do |matches|

--- a/spec/lib/book_spec.rb
+++ b/spec/lib/book_spec.rb
@@ -27,6 +27,7 @@ describe BibleBot::Book do
   describe "find_by_name" do
     [
       {name: "genesis", expected: "Genesis"},
+      {name: "gènesis", expected: "Genesis"},
       {name: "psalm", expected: "Psalms"},
       {name: "rev", expected: "Revelation"},
       {name: "I’m Feeling", expected: nil},

--- a/spec/lib/reference_match_spec.rb
+++ b/spec/lib/reference_match_spec.rb
@@ -25,6 +25,7 @@ describe BibleBot::ReferenceMatch do
       {ref: "Genesis 3 - Genesis 4:3", expected: ["Genesis 3:1-4:3"]},
       {ref: "Ex", expected: []},
       {ref: "Genesis 1:1", expected: ["Genesis 1:1"]},
+      {ref: "Gènesis 1:1", expected: ["Genesis 1:1"]},
       {ref: "Ge 1:1", expected: ["Genesis 1:1"]},
       {ref: "Gen 1:1", expected: ["Genesis 1:1"]},
       {ref: "Gn 1:1", expected: ["Genesis 1:1"]},


### PR DESCRIPTION
David searched "Gènesis 1:26" and it errored.

https://dwell-bible.sentry.io/issues/5743011428/?alert_rule_id=14999018&alert_timestamp=1724329856888&alert_type=email&environment=production&notification_uuid=cc7da139-5f4f-42db-a3de-f18b0f6ee1cc&project=6326639&referrer=alert_email