### PR TITLE
Update apocryphal to deuterocanonical references

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,19 +133,19 @@ verse == other_verse
 verse > other_verse
 ```
 
-## Apocryphal References
+## Deuterocanonical References
 
-If you want to match apocryphal references in your strings, you can enable a collection of matchers like this:
+If you want to match Deuterocanonical references in your strings, you can enable a collection of matchers like this:
 
 ```ruby
-BibleBot.include_apocryphal_content = true
+BibleBot.include_dcn_content = true
 
 ReferenceMatch.scan( "Tob 1:1" ).first.reference.formatted
 
 # > "Tobit 1:1"
 ```
 
-You can see the supported apocryphal works in [bible.rb](https://github.com/LittleLea/bible_bot/blob/b94fe9b3948ceb23d39961ffdc4bdf7ffe23eff3/lib/bible_bot/bible.rb#L537)
+You can see the supported deuterocanonical works in [bible.rb](https://github.com/LittleLea/bible_bot/blob/b94fe9b3948ceb23d39961ffdc4bdf7ffe23eff3/lib/bible_bot/bible.rb#L537)
 
 ## History
 


### PR DESCRIPTION
Updating documentation to reflect accurate terminology. There are no "Apocryphal" works supported by this project. "Apocryphal" includes non accepted works of Scripture (in any denomination) such as "The Gospel of Peter" or "The Gospel of Thomas". Method name change/module reference will follow suit.